### PR TITLE
fix for CMake 3.19

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(SMHasher)
 
-cmake_minimum_required(VERSION 2.4)
-
 set(CMAKE_BUILD_TYPE Release)
 
 add_library(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(SMHasher)
 
+cmake_minimum_required(VERSION 3.0)
+
 set(CMAKE_BUILD_TYPE Release)
 
 add_library(


### PR DESCRIPTION
CMake 3.19 is warning about 
```code
CMake Deprecation Warning at deps/smhasher/src/CMakeLists.txt:3 (cmake_minimum_required):
1>  Compatibility with CMake < 2.8.12 will be removed from a future version of
1>  CMake.
```

CMake version 2.4 was released around 2006 (https://blog.kitware.com/cmake-2-4-2-released/). About 14 years ago. I believe CMake support can migrate to the current version seeing as the CMakelists.txt is extremely clean and neat.

Best Regards,
Andrei Porumb

